### PR TITLE
Update for and pin YAML to 3.13

### DIFF
--- a/mass_shoot_bot.py
+++ b/mass_shoot_bot.py
@@ -37,7 +37,7 @@ def load_yaml(filename):
     wordnik_api_key: TODO_ENTER_YOURS
     """
     with open(filename) as f:
-        data = yaml.safe_load(f)
+        data = yaml.load(f)
 
     if not data.keys() >= {
         "access_token",
@@ -58,7 +58,7 @@ def save_yaml(filename, data):
     Save data to filename in YAML format
     """
     with open(filename, "w") as yaml_file:
-        yaml_file.write(yaml.safe_dump(data, default_flow_style=False))
+        yaml_file.write(yaml.dump(data, default_flow_style=False))
 
 
 def tweet_it(string, credentials, image=None, location=None):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 inflect
 python-dateutil
 pytz
-pyyaml
+pyyaml==3.13
 twitter


### PR DESCRIPTION
There's been some changes in `safe_dump`/`dump` and `safe_load`/`load`, and release retractions of PyYAML 4, so pin to known working behaviour of 3.13.

Around 14th November, it started logging an error like this:

```
Traceback (most recent call last):
  File "mass_shoot_bot.py", line 306, in <module>
    data = load_yaml(args.yaml)
  File "mass_shoot_bot.py", line 42, in load_yaml
    if not data.keys() >= {
AttributeError: 'NoneType' object has no attribute 'keys'
```

That's because `safe_dump` had caused the YAML file to be wiped:

```
Traceback (most recent call last):
  File "mass_shoot_bot.py", line 318, in <module>
    save_yaml("test.yaml", data)
  File "mass_shoot_bot.py", line 62, in save_yaml
    yaml_file.write(yaml.safe_dump(data, default_flow_style=False))
  File "/usr/local/lib/python3.7/site-packages/yaml/__init__.py", line 216, in safe_dump
    return dump_all([data], stream, Dumper=SafeDumper, **kwds)
  File "/usr/local/lib/python3.7/site-packages/yaml/__init__.py", line 188, in dump_all
    dumper.represent(data)
  File "/usr/local/lib/python3.7/site-packages/yaml/representer.py", line 26, in represent
    node = self.represent_data(data)
  File "/usr/local/lib/python3.7/site-packages/yaml/representer.py", line 47, in represent_data
    node = self.yaml_representers[data_types[0]](self, data)
  File "/usr/local/lib/python3.7/site-packages/yaml/representer.py", line 205, in represent_dict
    return self.represent_mapping('tag:yaml.org,2002:map', data)
  File "/usr/local/lib/python3.7/site-packages/yaml/representer.py", line 116, in represent_mapping
    node_value = self.represent_data(item_value)
  File "/usr/local/lib/python3.7/site-packages/yaml/representer.py", line 57, in represent_data
    node = self.yaml_representers[None](self, data)
  File "/usr/local/lib/python3.7/site-packages/yaml/representer.py", line 229, in represent_undefined
    raise RepresenterError("cannot represent an object: %s" % data)
yaml.representer.RepresenterError: cannot represent an object: OrderedDict([('Incident Date', 'January 5, 2018'), ('State', 'Mississippi'), ('City Or County', 'Hattiesburg'), ('Address', '6168 US 49'), ('# Killed', '0'), ('# Injured', '6'), ('Operations', 'N/A')])
```

Changing it to `dump` allows it to be saved. Also need to change it to `load` to prevent:

```
Traceback (most recent call last):
  File "mass_shoot_bot.py", line 306, in <module>
    data = load_yaml(args.yaml)
  File "mass_shoot_bot.py", line 40, in load_yaml
    data = yaml.safe_load(f)
  File "/usr/local/lib/python3.7/site-packages/yaml/__init__.py", line 94, in safe_load
    return load(stream, SafeLoader)
  File "/usr/local/lib/python3.7/site-packages/yaml/__init__.py", line 72, in load
    return loader.get_single_data()
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 37, in get_single_data
    return self.construct_document(node)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 46, in construct_document
    for dummy in generator:
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 398, in construct_yaml_map
    value = self.construct_mapping(node)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 204, in construct_mapping
    return super().construct_mapping(node, deep=deep)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 129, in construct_mapping
    value = self.construct_object(value_node, deep=deep)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 86, in construct_object
    data = constructor(self, node)
  File "/usr/local/lib/python3.7/site-packages/yaml/constructor.py", line 414, in construct_undefined
    node.start_mark)
yaml.constructor.ConstructorError: could not determine a constructor for the tag 'tag:yaml.org,2002:python/object/apply:collections.OrderedDict'
  in "test.yaml", line 5, column 16
```